### PR TITLE
Grid update

### DIFF
--- a/lib/grid/show-grid.es6.js
+++ b/lib/grid/show-grid.es6.js
@@ -87,7 +87,7 @@ var showGrid = function showGrid(columns, containerColumns, direction) {
   }, [directions.direction === 'right' ? 'to right' : 'to left']);
 
   return {
-    'background-image': 'linear-gradient(' + gradient.join(',') + ')',
+    'background': 'linear-gradient(' + gradient.join(',') + ')',
   };
 };
 

--- a/lib/grid/show-grid.es6.js
+++ b/lib/grid/show-grid.es6.js
@@ -35,6 +35,12 @@ var _coreFunctionsEs6Js = require('../core/functions.es6.js');
 //      max-width: 128em;
 //      margin-left: auto;
 //      margin-right: auto;
+//      background: linear-gradient(to right,
+//      #ecf0f1 0, #ecf0f1 31.7615656%,
+//      transparent 31.7615656%, transparent 34.1192172%,
+//      #ecf0f1 34.1192172%, #ecf0f1 65.88078280%,
+//      transparent 65.88078280%, transparent 68.2384344%,
+//      #ecf0f1 68.2384344%, #ecf0f1 100%);
 //    }
 //    .element:before,
 //    .element:after {
@@ -43,18 +49,6 @@ var _coreFunctionsEs6Js = require('../core/functions.es6.js');
 //    }
 //    .element:after {
 //      clear: both;
-//      background: linear-gradient(to right,
-//        #ecf0f1 0, #ecf0f1 31.7615656%,
-//        transparent 31.7615656%, transparent 34.1192172%,
-//        #ecf0f1 34.1192172%, #ecf0f1 65.88078280%,
-//        transparent 65.88078280%, transparent 68.2384344%,
-//        #ecf0f1 68.2384344%, #ecf0f1 100%);
-//      bottom: 0;
-//      display: block;
-//      left: 0;
-//      position: absolute;
-//      right: 0;
-//      top: 0
 //    }
 //
 
@@ -93,15 +87,7 @@ var showGrid = function showGrid(columns, containerColumns, direction) {
   }, [directions.direction === 'right' ? 'to right' : 'to left']);
 
   return {
-    '&:after': {
-      'background': 'linear-gradient(' + gradient.join(',') + ')',
-      'bottom': '0',
-      'display': 'block',
-      'left': '0',
-      'position': 'absolute',
-      'right': '0',
-      'top': '0'
-    }
+    'background-image': 'linear-gradient(' + gradient.join(',') + ')',
   };
 };
 


### PR DESCRIPTION
Currently it would conflict with any existing styles applied to the
after pseudo element. Lets say you have a container which has two
columns, neat will also apply a clearfix on it. When a grid is added,
the grid will never show because of the display: table being applied by
the clearfix which effectively hides the grid. Whats more is that since
the grid was positioned absolute, it will also rely on the container to
have a position relative on it - which can cause issues when debugging.
My proposal still applies the grid as a background but doesn’t require
the container to have position relative nor does it need the grid to be positioned
absolute - which could conflict with any cleafixes applied.